### PR TITLE
Add @online entry type to parser

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -92,7 +92,8 @@ function BibtexParser(arg0) {
     'periodical'        : 13,
     'booklet'           : 14,
     'masterthesis'      : 15,
-    'conference'        : 16
+    'conference'        : 16,
+    'online'            : 17
   }
   /** @private */ this.MACROS_        = {
     'jan'               : 'January',


### PR DESCRIPTION
Adds `@online` entry type to parser.

We have found that `@online` is quite popular in real-world usage of biblatex, so adding as an entry type would be useful.